### PR TITLE
Wiki/tautan gambar rusak

### DIFF
--- a/BlankOn.md
+++ b/BlankOn.md
@@ -20,7 +20,7 @@ menghasilkan, apa pun bentuknya, mulai dari kode, pemikiran-pemikiran, karya
 seni, hingga kegiatan-kegiatan bisnis yang menguntungkan.
 
 Ekosistem yang tercipta diharapkan akan menghasilkan beragam produk dan hasil
-karya, dan menjadi ​Swacala_Abadi yang kembali memberi manfaat ke proyek
+karya, dan menjadi [swacala abadi](https://en.wikipedia.org/wiki/Perpetual_motion) yang kembali memberi manfaat ke proyek
 BlankOn dalam bentuk dana, masukan-masukan, dan tenaga.
 
 Distribusi Linux BlankOn dijadikan ajang latihan untuk mencapai cita-cita ini.
@@ -37,13 +37,13 @@ waktu yang perlu dihabiskan.
 Saat ini mental kebanyakan dari kita adalah mental pembeli dan pengguna. Pasar
 dalam negeri dipenuhi barang-barang dan produksi luar negeri.
 
-![](/wiki/Assets/Images/produk-luar-negeri.png)
+![](https://raw.githubusercontent.com/BlankOn/wiki/master/Assets/Images/produk-luar-negeri.png)
 
 BlankOn ingin berpartisipasi dalam mengubah mental tersebut menjadi mental
 produsen dan penghasil. Ekosistem yang dicita-citakan merupakan sarana untuk
 mencapai transformasi ini.
 
-![](/wiki/Assets/Images/produk-sendiri.png)
+![](https://raw.githubusercontent.com/BlankOn/wiki/master/Assets/Images/produk-sendiri.png)
 
 ### Daftar Singkat Indikator Keberhasilan
 Berikut adalah beberapa contoh hal-hal yang menjadi indikator keberhasilan misi

--- a/BlankOn.md
+++ b/BlankOn.md
@@ -1,5 +1,5 @@
 # BlankOn
-![](/wiki/Assets/Images/buatan-indonesia.png)
+![Buatan Indonesia](https://raw.githubusercontent.com/BlankOn/wiki/master/Assets/Images/buatan-indonesia.png)
 
 ## Misi Proyek BlankOn
 Proyek BlankOn bertujuan untuk mengembangkan ekosistem baru dalam konteks


### PR DESCRIPTION
# Perubahan dalam PR:
 - Perbaikan tautan menuju artikel swacala abadi
 - Perbaikan tautan-tautan gambar pada halaman BlankOn.md

Sebelum:
<img width="925" alt="image" src="https://user-images.githubusercontent.com/23289654/65829210-fd286700-e2cc-11e9-95d9-d0d0ca8dc540.png">
Sesudah:
![Kapture 2019-09-29 at 15 23 15](https://user-images.githubusercontent.com/23289654/65829226-277a2480-e2cd-11e9-83f5-17083d627fe8.gif)
